### PR TITLE
fstests: add a test to exercise the new rescue mount options for btrfs

### DIFF
--- a/tests/btrfs/227
+++ b/tests/btrfs/227
@@ -1,0 +1,99 @@
+#! /bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2020 Facebook.  All Rights Reserved.
+#
+# FS QA Test 227
+#
+# A test to exercise the various failure scenarios for -o rescue=all.  This is
+# mainly a regression test for
+#
+#   btrfs: introduce rescue=all
+#
+# We simply corrupt a bunch of core roots and validate that it works the way we
+# expect it to.
+#
+seq=`basename $0`
+seqres=$RESULT_DIR/$seq
+echo "QA output created by $seq"
+
+here=`pwd`
+tmp=/tmp/$$
+status=1	# failure is the default!
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_cleanup()
+{
+	cd /
+	rm -f $tmp.*
+}
+
+_generate_fs()
+{
+	# We need single so we don't just read the duplicates
+	_scratch_mkfs -m single -d single > $seqres.full 2>&1
+	_scratch_mount
+	$XFS_IO_PROG -f -c "pwrite -S 0xab 0 1M" $SCRATCH_MNT/foo | \
+		_filter_xfs_io
+	md5sum $SCRATCH_MNT/foo | _filter_scratch
+	_scratch_unmount
+}
+
+_clear_root()
+{
+	# Grab the bytenr for the root by dumping the tree roots, clearing up to
+	# the key so our first column is the bytenr.  With a normal device with
+	# single should mean that physical == logical
+	local bytenr=$($BTRFS_UTIL_PROG inspect-internal dump-tree -r \
+		$SCRATCH_DEV | grep "$1" | sed 's/.*) //g'| \
+		awk '{ print $1 }')
+	dd if=/dev/zero of=$SCRATCH_DEV bs=1 seek=$bytenr count=4096 | \
+		_filter_dd
+}
+
+_test_failure()
+{
+	_try_scratch_mount $* > /dev/null 2>&1
+	[ $? -eq 0 ] && _fail "We should have failed to mount"
+}
+
+_test_success()
+{
+	_generate_fs
+	_clear_root "$1"
+	_test_failure
+	_scratch_mount -o rescue=all,ro
+	md5sum $SCRATCH_MNT/foo | _filter_scratch
+	_scratch_unmount
+}
+
+# get standard environment, filters and checks
+. ./common/rc
+. ./common/filter
+
+# remove previous $seqres.full before test
+rm -f $seqres.full
+
+# real QA test starts here
+
+_supported_fs generic
+_supported_os Linux
+_require_test
+_require_scratch_mountopt "rescue=all,ro"
+
+# Test with the roots that should definitely pass
+_test_success "extent tree"
+_test_success "checksum tree"
+_test_success "uuid tree"
+_test_success "data reloc"
+
+# Now test the roots that will definitely fail
+_generate_fs
+_clear_root "fs tree"
+_test_failure -o rescue=all,ro
+
+# We have to re-mkfs the fs because otherwise the post-test fsck will blow up
+_scratch_mkfs > /dev/null 2>&1
+
+# success, all done
+status=0
+exit

--- a/tests/btrfs/227.out
+++ b/tests/btrfs/227.out
@@ -1,0 +1,30 @@
+QA output created by 227
+wrote 1048576/1048576 bytes at offset 0
+XXX Bytes, X ops; XX:XX:XX.X (XXX YYY/sec and XXX ops/sec)
+096003817ad2638000a6836e55866697  SCRATCH_MNT/foo
+4096+0 records in
+4096+0 records out
+096003817ad2638000a6836e55866697  SCRATCH_MNT/foo
+wrote 1048576/1048576 bytes at offset 0
+XXX Bytes, X ops; XX:XX:XX.X (XXX YYY/sec and XXX ops/sec)
+096003817ad2638000a6836e55866697  SCRATCH_MNT/foo
+4096+0 records in
+4096+0 records out
+096003817ad2638000a6836e55866697  SCRATCH_MNT/foo
+wrote 1048576/1048576 bytes at offset 0
+XXX Bytes, X ops; XX:XX:XX.X (XXX YYY/sec and XXX ops/sec)
+096003817ad2638000a6836e55866697  SCRATCH_MNT/foo
+4096+0 records in
+4096+0 records out
+096003817ad2638000a6836e55866697  SCRATCH_MNT/foo
+wrote 1048576/1048576 bytes at offset 0
+XXX Bytes, X ops; XX:XX:XX.X (XXX YYY/sec and XXX ops/sec)
+096003817ad2638000a6836e55866697  SCRATCH_MNT/foo
+4096+0 records in
+4096+0 records out
+096003817ad2638000a6836e55866697  SCRATCH_MNT/foo
+wrote 1048576/1048576 bytes at offset 0
+XXX Bytes, X ops; XX:XX:XX.X (XXX YYY/sec and XXX ops/sec)
+096003817ad2638000a6836e55866697  SCRATCH_MNT/foo
+4096+0 records in
+4096+0 records out

--- a/tests/btrfs/350
+++ b/tests/btrfs/350
@@ -1,0 +1,72 @@
+#! /bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2020 Facebook.  All Rights Reserved.
+#
+# FS QA Test 350
+#
+# Regression test for the problem fixed by the patch
+#
+#  btrfs: init device stats for seed devices
+#
+# Make a seed device, add a sprout to it, and then make sure we can still read
+# the device stats for both devices after we remount with the new sprout device.
+#
+seq=`basename $0`
+seqres=$RESULT_DIR/$seq
+echo "QA output created by $seq"
+
+here=`pwd`
+tmp=/tmp/$$
+status=1	# failure is the default!
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_cleanup()
+{
+	cd /
+	rm -f $tmp.*
+}
+
+# get standard environment, filters and checks
+. ./common/rc
+. ./common/filter
+. ./common/filter.btrfs
+
+# remove previous $seqres.full before test
+rm -f $seqres.full
+
+# real QA test starts here
+
+# Modify as appropriate.
+_supported_fs btrfs
+_require_test
+_require_scratch_dev_pool 2
+
+_scratch_dev_pool_get 2
+
+dev_seed=$(echo $SCRATCH_DEV_POOL | awk '{print $1}')
+dev_sprout=$(echo $SCRATCH_DEV_POOL | awk '{print $2}')
+
+# Create the seed device
+_mkfs_dev $dev_seed
+_mount $dev_seed $SCRATCH_MNT
+$XFS_IO_PROG -f -d -c "pwrite -S 0xab 0 1M" $SCRATCH_MNT/foo > /dev/null
+$BTRFS_UTIL_PROG filesystem show -m $SCRATCH_MNT | \
+	_filter_btrfs_filesystem_show
+_scratch_unmount
+$BTRFS_TUNE_PROG -S 1 $dev_seed
+
+# Mount the seed device and add the rw device
+_mount -o ro $dev_seed $SCRATCH_MNT
+_run_btrfs_util_prog device add -f $dev_sprout $SCRATCH_MNT
+$BTRFS_UTIL_PROG device stats $SCRATCH_MNT | _filter_scratch_pool
+_scratch_unmount
+
+# Now remount, validate the device stats do not fail
+_mount $dev_sprout $SCRATCH_MNT
+$BTRFS_UTIL_PROG device stats $SCRATCH_MNT | _filter_scratch_pool
+
+_scratch_dev_pool_put
+
+# success, all done
+status=0
+exit

--- a/tests/btrfs/350.out
+++ b/tests/btrfs/350.out
@@ -1,0 +1,25 @@
+QA output created by 350
+Label: none  uuid: <UUID>
+	Total devices <NUM> FS bytes used <SIZE>
+	devid <DEVID> size <SIZE> used <SIZE> path SCRATCH_DEV
+
+[SCRATCH_DEV].write_io_errs    0
+[SCRATCH_DEV].read_io_errs     0
+[SCRATCH_DEV].flush_io_errs    0
+[SCRATCH_DEV].corruption_errs  0
+[SCRATCH_DEV].generation_errs  0
+[SCRATCH_DEV].write_io_errs    0
+[SCRATCH_DEV].read_io_errs     0
+[SCRATCH_DEV].flush_io_errs    0
+[SCRATCH_DEV].corruption_errs  0
+[SCRATCH_DEV].generation_errs  0
+[SCRATCH_DEV].write_io_errs    0
+[SCRATCH_DEV].read_io_errs     0
+[SCRATCH_DEV].flush_io_errs    0
+[SCRATCH_DEV].corruption_errs  0
+[SCRATCH_DEV].generation_errs  0
+[SCRATCH_DEV].write_io_errs    0
+[SCRATCH_DEV].read_io_errs     0
+[SCRATCH_DEV].flush_io_errs    0
+[SCRATCH_DEV].corruption_errs  0
+[SCRATCH_DEV].generation_errs  0

--- a/tests/btrfs/group
+++ b/tests/btrfs/group
@@ -228,3 +228,4 @@
 224 auto quick qgroup
 225 auto quick volume seed
 226 auto quick rw snapshot clone prealloc punch
+350 auto quick volume seed

--- a/tests/btrfs/group
+++ b/tests/btrfs/group
@@ -228,4 +228,5 @@
 224 auto quick qgroup
 225 auto quick volume seed
 226 auto quick rw snapshot clone prealloc punch
+227 auto quick
 350 auto quick volume seed


### PR DESCRIPTION
This test exercises the various recovery options in btrfs, that were
introduced with the following patches

  btrfs: introduce rescue=ignorebadroots
  btrfs: introduce rescue=ignoredatacsums
  btrfs: introduce rescue=all

Signed-off-by: Josef Bacik <josef@toxicpanda.com>