### PR TITLE
tests for space_cache remounts

### DIFF
--- a/common/btrfs
+++ b/common/btrfs
@@ -411,3 +411,15 @@ _btrfs_forget_or_module_reload()
 
 	_reload_fs_module "btrfs"
 }
+
+# print whether or not the free space tree is enabled on the scratch dev
+_btrfs_free_space_tree_enabled()
+{
+	compat_ro="$($BTRFS_UTIL_PROG inspect-internal dump-super "$SCRATCH_DEV" | \
+		     sed -rn 's/^compat_ro_flags\s+(.*)$/\1/p')"
+	if ((compat_ro & 0x1)); then
+		echo "free space tree is enabled"
+	else
+		echo "free space tree is disabled"
+	fi
+}

--- a/tests/btrfs/131
+++ b/tests/btrfs/131
@@ -51,17 +51,6 @@ mkfs_v2()
 	_scratch_unmount
 }
 
-check_fst_compat()
-{
-	compat_ro="$($BTRFS_UTIL_PROG inspect-internal dump-super "$SCRATCH_DEV" | \
-		     sed -rn 's/^compat_ro_flags\s+(.*)$/\1/p')"
-	if ((compat_ro & 0x1)); then
-		echo "free space tree is enabled"
-	else
-		echo "free space tree is disabled"
-	fi
-}
-
 # Mount options might interfere.
 export MOUNT_OPTIONS=""
 
@@ -75,19 +64,19 @@ export MOUNT_OPTIONS=""
 mkfs_v1
 echo "Using free space cache"
 _scratch_mount -o space_cache=v1
-check_fst_compat
+_btrfs_free_space_tree_enabled
 _scratch_unmount
 
 mkfs_v1
 echo "Enabling free space tree"
 _scratch_mount -o space_cache=v2
-check_fst_compat
+_btrfs_free_space_tree_enabled
 _scratch_unmount
 
 mkfs_v1
 echo "Disabling free space cache and enabling free space tree"
 _scratch_mount -o clear_cache,space_cache=v2
-check_fst_compat
+_btrfs_free_space_tree_enabled
 _scratch_unmount
 
 # When the free space tree is enabled:
@@ -105,32 +94,32 @@ _try_scratch_mount -o space_cache=v1 >/dev/null 2>&1 || echo "mount failed"
 mkfs_v2
 echo "Mounting existing free space tree"
 _scratch_mount
-check_fst_compat
+_btrfs_free_space_tree_enabled
 _scratch_unmount
 _scratch_mount -o space_cache=v2
-check_fst_compat
+_btrfs_free_space_tree_enabled
 _scratch_unmount
 
 mkfs_v2
 echo "Recreating free space tree"
 _scratch_mount -o clear_cache,space_cache=v2
-check_fst_compat
+_btrfs_free_space_tree_enabled
 _scratch_unmount
 mkfs_v2
 _scratch_mount -o clear_cache
-check_fst_compat
+_btrfs_free_space_tree_enabled
 _scratch_unmount
 
 mkfs_v2
 echo "Disabling free space tree"
 _scratch_mount -o clear_cache,nospace_cache
-check_fst_compat
+_btrfs_free_space_tree_enabled
 _scratch_unmount
 
 mkfs_v2
 echo "Reverting to free space cache"
 _scratch_mount -o clear_cache,space_cache=v1
-check_fst_compat
+_btrfs_free_space_tree_enabled
 _scratch_unmount
 
 # success, all done

--- a/tests/btrfs/281
+++ b/tests/btrfs/281
@@ -1,0 +1,157 @@
+#! /bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2020 YOUR NAME HERE.  All Rights Reserved.
+#
+# FS QA Test 281
+#
+# what am I here for?
+#
+seq=`basename $0`
+seqres=$RESULT_DIR/$seq
+echo "QA output created by $seq"
+
+here=`pwd`
+tmp=/tmp/$$
+status=1	# failure is the default!
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_cleanup()
+{
+	cd /
+	rm -f $tmp.*
+}
+
+# get standard environment, filters and checks
+. ./common/rc
+. ./common/filter
+
+# remove previous $seqres.full before test
+rm -f $seqres.full
+
+# real QA test starts here
+
+# Modify as appropriate.
+_supported_fs btrfs
+_require_scratch
+_require_btrfs_command inspect-internal dump-super
+_require_btrfs_fs_feature free_space_tree
+
+grep_opt() {
+	local opt=$1
+	shift
+	_fs_options $SCRATCH_DEV | tr ',' '\n' | egrep $@ "^$opt$" > /dev/null
+}
+
+expect_opt() {
+	local opt=$1
+	grep_opt $opt || _fail "missing $opt mount option"
+}
+
+expect_no_opt() {
+	local opt=$1
+	grep_opt $opt && _fail "unexpected $opt mount option"
+}
+
+expect_fst() {
+	_btrfs_free_space_tree_enabled | grep enabled > /dev/null || _fail "missing enabled fst"
+}
+
+expect_no_fst() {
+	_btrfs_free_space_tree_enabled | grep disabled > /dev/null || _fail "unexpected enabled fst"
+}
+
+expect_no() {
+	expect_opt nospace_cache
+	expect_no_opt space_cache
+	expect_no_opt space_cache=v2
+	expect_no_fst
+	expect_no_opt clear_cache
+}
+
+expect_v1() {
+	expect_no_opt nospace_cache
+	expect_opt space_cache
+	expect_no_opt space_cache=v2
+	expect_no_fst
+	expect_no_opt clear_cache
+}
+
+expect_v2() {
+	expect_no_opt nospace_cache
+	expect_no_opt space_cache
+	expect_opt space_cache=v2
+	expect_fst
+	expect_no_opt clear_cache
+}
+
+# Scenarios:
+# (non remount scenarios are covered by btrfs/131)
+# nospace_cache -> space_cache=v1 via ro->rw remount
+# nospace_cache -> space_cache=v2 via ro->rw remount
+# space_cache=v1 -> space_cache=v2 via rw->rw remount (no change)
+# space_cache=v1 -> space_cache=v2 via ro->ro remount (no change)
+# space_cache=v1 -> space_cache=v2 via ro->rw remount
+# space_cache=v1 -> nospace_cache via rw->rw remount (?)
+# space_cache=v1 -> nospace_cache via ro->ro remount (?)
+# space_cache=v1 -> nospace_cache via ro->rw remount
+
+# TODO
+# v1 -> no rw->rw
+# no -> v1 rw->rw
+# mount option not applied, but does the behavior change "truly"??
+
+_scratch_mkfs >/dev/null 2>&1
+_scratch_mount -o clear_cache,nospace_cache
+expect_no
+echo "no -> v1 via rw->rw remount"
+_scratch_remount space_cache=v1
+expect_v1
+echo "v1 -> no via rw->rw remount"
+_scratch_remount rw,nospace_cache
+expect_no
+echo "no -> v1 via ro->rw remount"
+_scratch_remount ro
+_scratch_remount rw,space_cache=v1
+expect_v1
+echo "v1 -> no via ro->rw remount"
+_scratch_remount ro
+_scratch_remount rw,nospace_cache
+expect_no
+echo "no -> v2 via rw->rw remount (no change)"
+_scratch_remount space_cache=v2
+expect_no
+echo "no -> v2 via ro->rw remount"
+_scratch_remount ro
+_scratch_remount rw,space_cache=v2
+expect_v2
+echo "v2 -> v1 via rw->rw remount (no change)"
+_scratch_remount clear_cache,space_cache=v1
+expect_v2
+echo "v2 -> v1 via ro->rw remount"
+_scratch_remount ro
+_scratch_remount clear_cache,space_cache=v1
+expect_v1
+echo "v1 -> v2 via rw->rw remount (no change)"
+_scratch_remount space_cache=v2
+expect_v1
+# todo boris fixme to a generic dd
+dd if=/dev/zero of=/$SCRATCH_MNT/foo bs=1M count=10 2>/dev/null
+echo "v1 -> v2 via ro->ro remount (no change)"
+_scratch_remount ro
+_scratch_remount ro,space_cache=v2
+expect_v1
+echo "v1 -> v2 via ro->rw remount"
+_scratch_remount rw,space_cache=v2
+expect_v2
+echo "v2 -> no via ro->rw remount"
+_scratch_remount ro
+_scratch_remount rw,clear_cache,nospace_cache
+expect_no
+
+# optional stuff if your test has verbose output to help resolve problems
+#echo
+#echo "If failure, check $seqres.full (this) and $seqres.full.ok (reference)"
+
+# success, all done
+status=0
+exit

--- a/tests/btrfs/281.out
+++ b/tests/btrfs/281.out
@@ -1,0 +1,13 @@
+QA output created by 281
+no -> v1 via rw->rw remount
+v1 -> no via rw->rw remount
+no -> v1 via ro->rw remount
+v1 -> no via ro->rw remount
+no -> v2 via rw->rw remount (no change)
+no -> v2 via ro->rw remount
+v2 -> v1 via rw->rw remount (no change)
+v2 -> v1 via ro->rw remount
+v1 -> v2 via rw->rw remount (no change)
+v1 -> v2 via ro->ro remount (no change)
+v1 -> v2 via ro->rw remount
+v2 -> no via ro->rw remount

--- a/tests/btrfs/350
+++ b/tests/btrfs/350
@@ -1,0 +1,72 @@
+#! /bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2020 Facebook.  All Rights Reserved.
+#
+# FS QA Test 350
+#
+# Regression test for the problem fixed by the patch
+#
+#  btrfs: init device stats for seed devices
+#
+# Make a seed device, add a sprout to it, and then make sure we can still read
+# the device stats for both devices after we remount with the new sprout device.
+#
+seq=`basename $0`
+seqres=$RESULT_DIR/$seq
+echo "QA output created by $seq"
+
+here=`pwd`
+tmp=/tmp/$$
+status=1	# failure is the default!
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_cleanup()
+{
+	cd /
+	rm -f $tmp.*
+}
+
+# get standard environment, filters and checks
+. ./common/rc
+. ./common/filter
+. ./common/filter.btrfs
+
+# remove previous $seqres.full before test
+rm -f $seqres.full
+
+# real QA test starts here
+
+# Modify as appropriate.
+_supported_fs btrfs
+_require_test
+_require_scratch_dev_pool 2
+
+_scratch_dev_pool_get 2
+
+dev_seed=$(echo $SCRATCH_DEV_POOL | awk '{print $1}')
+dev_sprout=$(echo $SCRATCH_DEV_POOL | awk '{print $2}')
+
+# Create the seed device
+_mkfs_dev $dev_seed
+_mount $dev_seed $SCRATCH_MNT
+$XFS_IO_PROG -f -d -c "pwrite -S 0xab 0 1M" $SCRATCH_MNT/foo > /dev/null
+$BTRFS_UTIL_PROG filesystem show -m $SCRATCH_MNT | \
+	_filter_btrfs_filesystem_show
+_scratch_unmount
+$BTRFS_TUNE_PROG -S 1 $dev_seed
+
+# Mount the seed device and add the rw device
+_mount -o ro $dev_seed $SCRATCH_MNT
+_run_btrfs_util_prog device add -f $dev_sprout $SCRATCH_MNT
+$BTRFS_UTIL_PROG device stats $SCRATCH_MNT | _filter_scratch_pool
+_scratch_unmount
+
+# Now remount, validate the device stats do not fail
+_mount $dev_sprout $SCRATCH_MNT
+$BTRFS_UTIL_PROG device stats $SCRATCH_MNT | _filter_scratch_pool
+
+_scratch_dev_pool_put
+
+# success, all done
+status=0
+exit

--- a/tests/btrfs/350.out
+++ b/tests/btrfs/350.out
@@ -1,0 +1,25 @@
+QA output created by 350
+Label: none  uuid: <UUID>
+	Total devices <NUM> FS bytes used <SIZE>
+	devid <DEVID> size <SIZE> used <SIZE> path SCRATCH_DEV
+
+[SCRATCH_DEV].write_io_errs    0
+[SCRATCH_DEV].read_io_errs     0
+[SCRATCH_DEV].flush_io_errs    0
+[SCRATCH_DEV].corruption_errs  0
+[SCRATCH_DEV].generation_errs  0
+[SCRATCH_DEV].write_io_errs    0
+[SCRATCH_DEV].read_io_errs     0
+[SCRATCH_DEV].flush_io_errs    0
+[SCRATCH_DEV].corruption_errs  0
+[SCRATCH_DEV].generation_errs  0
+[SCRATCH_DEV].write_io_errs    0
+[SCRATCH_DEV].read_io_errs     0
+[SCRATCH_DEV].flush_io_errs    0
+[SCRATCH_DEV].corruption_errs  0
+[SCRATCH_DEV].generation_errs  0
+[SCRATCH_DEV].write_io_errs    0
+[SCRATCH_DEV].read_io_errs     0
+[SCRATCH_DEV].flush_io_errs    0
+[SCRATCH_DEV].corruption_errs  0
+[SCRATCH_DEV].generation_errs  0

--- a/tests/btrfs/group
+++ b/tests/btrfs/group
@@ -228,3 +228,4 @@
 224 auto quick qgroup
 225 auto quick volume seed
 226 auto quick rw snapshot clone prealloc punch
+350 auto quick volume seed

--- a/tests/btrfs/group
+++ b/tests/btrfs/group
@@ -228,4 +228,5 @@
 224 auto quick qgroup
 225 auto quick volume seed
 226 auto quick rw snapshot clone prealloc punch
+281 auto quick
 350 auto quick volume seed

--- a/tests/generic/614
+++ b/tests/generic/614
@@ -1,0 +1,50 @@
+#! /bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020 SUSE Linux Products GmbH. All Rights Reserved.
+#
+# FS QA Test No. 614
+#
+# Test that after doing a memory mapped write to an empty file, a call to
+# stat(2) reports a non-zero number of used blocks.
+#
+seq=`basename $0`
+seqres=$RESULT_DIR/$seq
+echo "QA output created by $seq"
+tmp=/tmp/$$
+status=1	# failure is the default!
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_cleanup()
+{
+	cd /
+	rm -f $tmp.*
+}
+
+# get standard environment, filters and checks
+. ./common/rc
+. ./common/filter
+
+# real QA test starts here
+_supported_fs generic
+_require_scratch
+
+rm -f $seqres.full
+
+_scratch_mkfs >>$seqres.full 2>&1
+_scratch_mount
+
+$XFS_IO_PROG -f -c "truncate 64K"      \
+	     -c "mmap -w 0 64K"        \
+	     -c "mwrite -S 0xab 0 64K" \
+	     -c "munmap"               \
+	     $SCRATCH_MNT/foobar | _filter_xfs_io
+
+blocks_used=$(stat -c %b $SCRATCH_MNT/foobar)
+if [ $blocks_used -eq 0 ]; then
+    echo "error: stat(2) reported 0 used blocks"
+fi
+
+echo "Silence is golden"
+
+status=0
+exit

--- a/tests/generic/614.out
+++ b/tests/generic/614.out
@@ -1,0 +1,2 @@
+QA output created by 614
+Silence is golden

--- a/tests/generic/615
+++ b/tests/generic/615
@@ -1,0 +1,84 @@
+#! /bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2020 SUSE Linux Products GmbH. All Rights Reserved.
+#
+# FS QA Test No. 615
+#
+# Test that if we keep overwriting an entire file, either with buffered writes
+# or direct IO writes, the number of used blocks reported by stat(2) is never
+# zero while writeback is in progress.
+#
+seq=`basename $0`
+seqres=$RESULT_DIR/$seq
+echo "QA output created by $seq"
+tmp=/tmp/$$
+status=1	# failure is the default!
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_cleanup()
+{
+	cd /
+	rm -f $tmp.*
+}
+
+# get standard environment, filters and checks
+. ./common/rc
+. ./common/filter
+
+# real QA test starts here
+_supported_fs generic
+_require_scratch
+_require_odirect
+
+rm -f $seqres.full
+
+stat_loop()
+{
+	trap "wait; exit" SIGTERM
+	local filepath=$1
+	local blocks
+
+	while :; do
+		blocks=$(stat -c %b $filepath)
+		if [ $blocks -eq 0 ]; then
+		    echo "error: stat(2) reported zero blocks"
+		    break
+		fi
+	done
+}
+
+_scratch_mkfs >>$seqres.full 2>&1
+_scratch_mount
+
+$XFS_IO_PROG -f -s -c "pwrite -b 64K 0 64K" $SCRATCH_MNT/foo > /dev/null
+
+stat_loop $SCRATCH_MNT/foo &
+loop_pid=$!
+
+echo "Testing buffered writes"
+
+# Now keep overwriting the entire file, triggering writeback after each write,
+# while another process is calling stat(2) on the file. We expect the number of
+# used blocks reported by stat(2) to be always greater than 0.
+for ((i = 0; i < 2000; i++)); do
+	if ! kill -s 0 $loop_pid &> /dev/null; then
+	    break
+	fi
+	$XFS_IO_PROG -s -c "pwrite -b 64K 0 64K" $SCRATCH_MNT/foo > /dev/null
+done
+
+echo "Testing direct IO writes"
+
+# Now similar to what we did before but for direct IO writes.
+for ((i = 0; i < 2000; i++)); do
+	if ! kill -s 0 $loop_pid &> /dev/null; then
+	    break
+	fi
+	$XFS_IO_PROG -d -c "pwrite -b 64K 0 64K" $SCRATCH_MNT/foo > /dev/null
+done
+
+kill $loop_pid &> /dev/null
+wait
+
+status=0
+exit

--- a/tests/generic/615.out
+++ b/tests/generic/615.out
@@ -1,0 +1,3 @@
+QA output created by 615
+Testing buffered writes
+Testing direct IO writes

--- a/tests/generic/group
+++ b/tests/generic/group
@@ -617,3 +617,4 @@
 612 auto quick clone
 613 auto quick encrypt
 614 auto quick rw
+615 auto rw

--- a/tests/generic/group
+++ b/tests/generic/group
@@ -616,3 +616,4 @@
 611 auto quick attr
 612 auto quick clone
 613 auto quick encrypt
+614 auto quick rw


### PR DESCRIPTION
There are a variety of interesting edge cases for transitions between
the different settings for free space cache. Some of these have had
somewhat undesirable behavior, particularly in how they appear in
/proc/mounts. This test aims to cover most of the interesting
transitions between "nospace_cache", "space_cache=v1", and
"space_cache=v2", particularly via remount. This is especially relevant
for root filesystems.

Fixes that make this test pass are in the series:
btrfs: free space tree mounting fixes

Signed-off-by: Boris Burkov <boris@bur.io>