### PR TITLE
fstests: guess proper MIN_FSSIZE when it's not set

### DIFF
--- a/common/rc
+++ b/common/rc
@@ -950,10 +950,27 @@ _available_memory_bytes()
 	fi
 }
 
+_guess_minimal_fs_size()
+{
+	[ -n "$MIN_FSSIZE" ] && return
+
+	case "$FSTYP" in
+	btrfs)
+		if _scratch_btrfs_is_zoned; then
+			sdev="$(_short_dev $SCRATCH_DEV)"
+			zone_size=$(($(cat /sys/block/${sdev}/queue/chunk_sectors) << 9))
+			# Assumes -d single -m dup for now
+			MIN_FSSIZE=$(( 12 * zone_size ))
+		fi
+		;;
+	esac
+}
+
 _check_minimal_fs_size()
 {
 	local fssize=$1
 
+	_guess_minimal_fs_size
 	if [ -n "$MIN_FSSIZE" ]; then
 		[ $MIN_FSSIZE -gt "$fssize" ] &&
 			_notrun "specified filesystem size is too small"
@@ -982,6 +999,7 @@ _small_fs_size_mb()
 	esac
 	(( size < fs_min_size )) && size="$fs_min_size"
 
+	_guess_minimal_fs_size
 	# If the test runner wanted a minimum size, enforce that here.
 	test -n "$MIN_FSSIZE" && runner_min_size=$((MIN_FSSIZE / 1048576))
 	(( size < runner_min_size)) && size="$runner_min_size"


### PR DESCRIPTION
This will fix test-zoned CI failures like:

https://github.com/btrfs/linux/actions/runs/9086266792/job/24977154400#step:2:205

Setting MIN_FSSIZE is necssary to skip a test, which create a FS with a too small size. It is especially necesarry for the zoned case. Without that, there will be many failed tests.

Guess a proper MIN_FSSIZE if not set, and skip such tests.

Currently, it assumes that a FS will be formated with "-d single -m dup" (default) option. That can still conver all the RAID/DUP cases except "-d dup -m dup".